### PR TITLE
Add support for gettext interface change in Python 3

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
@@ -2,6 +2,7 @@
 
 import webbrowser
 import gettext
+import sys
 
 import kivy
 kivy.require('{{cookiecutter.kivy_version}}')
@@ -190,4 +191,8 @@ class {{cookiecutter.app_class_name}}(App):
         locales = gettext.translation(
             '{{cookiecutter.repo_name}}', locale_dir, languages=[self.language]
         )
-        self.translation = locales.ugettext
+
+        if sys.version_info.major >= 3:
+            self.translation = locales.gettext
+        else:
+            self.translation = locales.ugettext


### PR DESCRIPTION
In Python 3, the GNU translation object's `ugettext` method was renamed to `gettext`. This commit adds a check for Python version and adjusts the call to `gettext` accordingly.